### PR TITLE
Fix bug in GET /v1/fact

### DIFF
--- a/kitapi/core/__init__.py
+++ b/kitapi/core/__init__.py
@@ -1,6 +1,4 @@
-from . import errors
-from . import models
-from . import settings
+from . import errors, models, settings
 from .errors import *
 
 __all__: list[str] = ["models", "settings"]

--- a/kitapi/main.py
+++ b/kitapi/main.py
@@ -1,9 +1,8 @@
 import uvloop
 from tortoise.contrib.fastapi import register_tortoise
 
-from kitapi.v1 import api
 from kitapi.core import settings
-
+from kitapi.v1 import api
 
 uvloop.install()
 

--- a/kitapi/v1/endpoints/fact.py
+++ b/kitapi/v1/endpoints/fact.py
@@ -1,10 +1,9 @@
-import random
 import typing as t
 
 from fastapi import APIRouter, Header, HTTPException
 
-from kitapi.v1 import utils
 from kitapi.core.models import *
+from kitapi.v1 import utils
 
 __all__: list[str] = ["FactRouter"]
 
@@ -27,8 +26,7 @@ FactRouter = APIRouter()
 @utils.with_request_update
 async def get_a_random_fact() -> Fact:
     """Gets a random fact."""
-    id = random.randint(1, await utils.get_fact_total())
-    obj = await Facts.get(id=id)
+    obj = await utils.get_random_fact()
     obj.uses += 1
     await obj.save()
     return await Fact.from_tortoise_orm(obj)

--- a/kitapi/v1/utils.py
+++ b/kitapi/v1/utils.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import random
 import typing as t
 
 from fastapi.exceptions import HTTPException
@@ -7,14 +8,15 @@ from fastapi.exceptions import HTTPException
 from kitapi import core
 
 
-async def get_fact_total() -> int:
+async def get_random_fact() -> core.models.Facts:
     """Gets the total number of facts in the database."""
-    data = await core.models.Facts.all().order_by("-id").limit(1).first()
+    count = await core.models.Facts.all().count()
+    data = (await core.models.Facts.all())[random.randint(0, count - 1)]
 
     if not data:
         raise core.DatabaseConnectionError("Failed to query the database.")
 
-    return data.id
+    return data
 
 
 async def get_request_total() -> int:


### PR DESCRIPTION
This now chooses a random element in the length of the returned list, rather than a random id in the range 1-highest id. 

This will no longer produce 404's.

Closes #1 